### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "undici": "^7.16.0",
     "webpack": "^5.101.3",
     "webpack-cli": "^6.0.1",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "discord.js": "^14.22.1",
     "execa": "^9.6.0",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.1.0",
     "express-session": "^1.18.2",
     "file-loader": "^6.2.0",
     "fs-extra": "^11.3.1",
@@ -83,8 +84,7 @@
     "undici": "^7.16.0",
     "webpack": "^5.101.3",
     "webpack-cli": "^6.0.1",
-    "winston": "^3.17.0",
-    "express-rate-limit": "^8.1.0"
+    "winston": "^3.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3312,6 +3312,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-rate-limit@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "express-rate-limit@npm:8.1.0"
+  dependencies:
+    ip-address: "npm:10.0.1"
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: 10/ddd5deb3b66f2b0c39c2188041c7e8951c697b3ec964b987144eb1832f823b683c0d1c8f0a9d00176dd13eccdb492a214e8908ad03467d41ca43e0b492b9738e
+  languageName: node
+  linkType: hard
+
 "express-session@npm:^1.18.2":
   version: 1.18.2
   resolution: "express-session@npm:1.18.2"
@@ -4064,7 +4075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.0.1":
+"ip-address@npm:10.0.1, ip-address@npm:^10.0.1":
   version: 10.0.1
   resolution: "ip-address@npm:10.0.1"
   checksum: 10/09731acda32cd8e14c46830c137e7e5940f47b36d63ffb87c737331270287d631cf25aa95570907a67d3f919fdb25f4470c404eda21e62f22e0a55927f4dd0fb
@@ -4527,6 +4538,7 @@ __metadata:
     eslint-config-prettier: "npm:^10.1.8"
     execa: "npm:^9.6.0"
     express: "npm:^5.1.0"
+    express-rate-limit: "npm:^8.1.0"
     express-session: "npm:^1.18.2"
     file-loader: "npm:^6.2.0"
     fs-extra: "npm:^11.3.1"


### PR DESCRIPTION
Potential fix for [https://github.com/e-adrien/knockknock/security/code-scanning/1](https://github.com/e-adrien/knockknock/security/code-scanning/1)

To fix the missing rate limiting, a rate-limiting middleware (such as `express-rate-limit`) should be applied to the authentication route—specifically to the POST handler at `kUrlLoginPage`. This will control the number of failed or total login attempts a user or client can make in a given period, mitigating brute-force and DoS risks. The best approach is to:

- Install the `express-rate-limit` package.
- Import `rateLimit` from `express-rate-limit` at the top of `server/middlewares/authentication.ts`.
- Define a rate limiter configuration—typical practice is to allow a certain number of attempts per timeframe (e.g., 5 attempts per 15 minutes).
- Apply this limiter middleware specifically to the POST `/auth/login` route by passing it as the first argument to `router.post`.

Only code within `server/middlewares/authentication.ts` may be edited, so the fix involves modifying that file to import and apply the rate limiter as described.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
